### PR TITLE
Make Database a device proxy and added a factory method to build the …

### DIFF
--- a/src/tangojs/core/Connector.js
+++ b/src/tangojs/core/Connector.js
@@ -24,6 +24,13 @@ export function setConnector (conn) {
 export class Connector {
 
   /**
+   * Return the default database address
+   *
+   * @return {Promise<string,Error>}
+   */
+  get_database () { }
+
+  /**
    * @param {string} devname
    * @return {Promise<string,Error>}
    */

--- a/src/tangojs/core/api/Database.js
+++ b/src/tangojs/core/api/Database.js
@@ -1,10 +1,23 @@
 
 import { connector } from '../Connector'
+import { DeviceProxy } from './DeviceProxy'
 
-export class Database {
+export class Database extends DeviceProxy {
 
-  constructor () {
-    // empty
+  constructor (devname) {
+    super(devname)
+  }
+
+  /**
+   * Create an instance of the default Database proxy
+   *
+   * @param {string} pattern
+   * @return {Promise<Database,Error>}
+   */
+  static default () {
+    return connector.get_database().then(name => {
+      return new Database(name)
+    })
   }
 
   /**


### PR DESCRIPTION
…default database connection

This allows the client to access the database API with no brainer.

`        tangojs.core.api.Database.default()
           .then( db =>  {   
             const args = ["*","*"]
             const command = "DbGetDeviceList"
             const devDataIn = new tangojs.core.api.DeviceData(args)
             return db.command_inout(command, devDataIn)  
           })                                                              
           .then(list => {                                          
             for( var element in list.output){        
               console.log(element, list.output[element])
             }                                                                        
           })                                                                        
`

A factory method "default" has been introduce in order to deal the asynchronous of the underline connector call since the DeviceProxy constructor need a device name.
Any feed back is welcome.